### PR TITLE
Use APScheduler to block main loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ def main():
     logger = logging.getLogger("main")
     logger.info("Запуск приложения SMMaker")
 
-    # Инициализируем наш Scheduler (он сам внутри конструктора запускает фоновые задачи)
+    # Инициализируем планировщик
     scheduler = Scheduler()
 
     # Проверяем, есть ли активные расписания для VK или Telegram
@@ -107,9 +107,9 @@ def main():
     if has_vk_schedule or has_tg_schedule:
         logger.info("Найдены активные расписания — запускаем Scheduler")
         try:
-            # Просто держим процесс живым, пока APScheduler работает в фоне
-            while True:
-                pass
+            scheduler.start()
+            # Блокируем основной поток, пока планировщик работает
+            scheduler.scheduler.sleep()
         except (KeyboardInterrupt, SystemExit):
             logger.info("Остановка Scheduler по сигналу")
             scheduler.shutdown()


### PR DESCRIPTION
## Summary
- refactor Scheduler wrapper so jobs register on `start()`
- add helper methods to manage schedules
- call `scheduler.start()` and block via APScheduler `sleep()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_684308170cb8832a8a406818ed12b9fe