### PR TITLE
Update get_next_post docstring

### DIFF
--- a/src/sheets/sheets_client.py
+++ b/src/sheets/sheets_client.py
@@ -98,8 +98,11 @@ class SheetsClient:
 
     def get_next_post(self, sheet_name: str) -> Tuple[Optional[int], Optional[Dict[str, str]]]:
         """
-        Ищет в указанном листе первую строку, где колонка "status" == "ожидание".
-        Возвращает (row_number, row_data) или (None, None).
+        Ищет в указанном листе первую строку, где колонка "status" равна
+        "ожидание". Если такая строка найдена, возвращает кортеж ``(Post,
+        row_index)``, где ``Post`` — собранный из данных строки объект, а
+        ``row_index`` — её номер в таблице. Если подходящих строк нет,
+        возвращает ``(None, None)``.
         """
         try:
             sheet = self._open_sheet(sheet_name)


### PR DESCRIPTION
## Summary
- clarify the `get_next_post` docstring about returned tuple

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_6843417f6fb0832aaf3d7db7514fc78a