### PR TITLE
Remove invalid reference from docstring

### DIFF
--- a/src/modules/image_generators/openai_image_generator.py
+++ b/src/modules/image_generators/openai_image_generator.py
@@ -7,7 +7,7 @@ openai_image_generator.py
 обновлённая для openai-python>=1.0.0.
 
 Теперь вместо устаревшего `openai.Image.create(...)` используется `openai.images.generate(...)`.
-См. миграцию: :contentReference[oaicite:0]{index=0}
+См. миграцию.
 """
 
 import logging


### PR DESCRIPTION
## Summary
- clean up OpenAI image generator docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_684344e7674c832aa0c9752c9de5a4ef