### PR TITLE
Add user DB module and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ project-root/
    pip install -r requirements.txt
    ```
 4. Создайте файл `.env` согласно шаблону:
-   ```dotenv
+```dotenv
    OPENAI_API_KEY=your_openai_api_key
    YANDEX_API_KEY=your_yandex_api_key
    YANDEX_CLOUD_FOLDER_ID=your_yandex_folder_id
@@ -101,7 +101,32 @@ project-root/
      "post_intro":"Напиши вступление к статье о ...",
      "post_summary":"Сделай краткое резюме для поста."
    }
-   ```
+```
+
+## Регистрация пользователей
+
+Пользователи сохраняются в SQLite базе `data/app.db`. Добавить администратора
+можно через небольшой скрипт:
+
+```python
+from src.core.user_db import create_user
+
+create_user("admin", "secret")
+```
+
+Для проверки пароля используется SHA‑256 хеш.
+
+## Настройки через базу данных
+
+В той же базе хранится таблица `settings`. Параметры можно читать и изменять
+прямо из кода:
+
+```python
+from src.core.user_db import set_setting, get_setting
+
+set_setting("vk_enabled", "true")
+print(get_setting("vk_enabled"))
+```
 
 ## Запуск приложения
 

--- a/src/core/user_db.py
+++ b/src/core/user_db.py
@@ -1,0 +1,93 @@
+"""src/core/user_db.py
+
+Модуль для управления пользователями и настройками приложения через SQLite.
+Используется простая база данных `data/app.db` с двумя таблицами:
+  - users(username TEXT UNIQUE, password_hash TEXT)
+  - settings(key TEXT PRIMARY KEY, value TEXT)
+"""
+
+import os
+import sqlite3
+import hashlib
+
+DB_PATH = os.path.join(os.getcwd(), "data", "app.db")
+
+
+def init_db() -> None:
+    """Создаёт базу данных и таблицы, если их ещё нет."""
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL
+        );
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS settings (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+
+def create_user(username: str, password: str) -> None:
+    """Добавляет нового пользователя."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO users (username, password_hash) VALUES (?, ?);",
+        (username, _hash_password(password)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def authenticate(username: str, password: str) -> bool:
+    """Проверяет имя пользователя и пароль."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT password_hash FROM users WHERE username = ?;", (username,))
+    row = cursor.fetchone()
+    conn.close()
+    if not row:
+        return False
+    return row[0] == _hash_password(password)
+
+
+def set_setting(key: str, value: str) -> None:
+    """Сохраняет значение параметра в таблицу settings."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?);",
+        (key, value),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_setting(key: str) -> str | None:
+    """Возвращает значение параметра или None."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT value FROM settings WHERE key = ?;", (key,))
+    row = cursor.fetchone()
+    conn.close()
+    return row[0] if row else None

--- a/tests/test_user_db.py
+++ b/tests/test_user_db.py
@@ -1,0 +1,41 @@
+import os
+import sqlite3
+
+import pytest
+
+# Добавляем project root
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.core import user_db
+
+
+@pytest.fixture
+def temp_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(user_db, "DB_PATH", str(db_path))
+    user_db.init_db()
+    yield db_path
+
+
+def test_create_user(temp_db):
+    user_db.create_user("alice", "password")
+    conn = sqlite3.connect(user_db.DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT username FROM users WHERE username='alice'")
+    row = cur.fetchone()
+    conn.close()
+    assert row[0] == "alice"
+
+
+def test_authentication(temp_db):
+    user_db.create_user("bob", "secret")
+    assert user_db.authenticate("bob", "secret") is True
+    assert user_db.authenticate("bob", "wrong") is False
+    assert user_db.authenticate("ghost", "secret") is False
+
+
+def test_settings(temp_db):
+    user_db.set_setting("foo", "bar")
+    assert user_db.get_setting("foo") == "bar"
+    assert user_db.get_setting("unknown") is None


### PR DESCRIPTION
## Summary
- document user registration and DB-based settings in README
- implement simple SQLite-backed user/settings module
- add unit tests for user creation, auth and settings retrieval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: apscheduler and gspread)*
- `pytest tests/test_user_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a83686c832abb27229b07a31635