### PR TITLE
Add user-specific settings loader

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 
-from src.config.settings import settings
+from src.config.settings import settings, set_active_user
 from src.scheduler.scheduler import Scheduler, publish_for_vk, publish_for_telegram
 
 
@@ -93,6 +93,8 @@ def process_immediate():
 
 
 def main():
+    user_id = int(os.getenv("USER_ID", "1"))
+    set_active_user(user_id)
     setup_logging()
     logger = logging.getLogger("main")
     logger.info("Запуск приложения SMMaker")


### PR DESCRIPTION
## Summary
- support user-specific secrets stored in SQLite
- select active user at runtime in `main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_68432a80adf8832a9caf0674c912d7f9