### PR TITLE
Fix Sheets variables in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ project-root/
    VK_OWNER_ID=-<group_id>
    TG_TOKEN=your_telegram_bot_token
    TG_CHAT_ID=@your_channel_or_chat_id
-   GOOGLE_CREDENTIALS_PATH=/path/to/service_account.json
-   SHEETS_NAME=press
-   SHEETS_TAB=smm
+  GOOGLE_CREDENTIALS_PATH=/path/to/service_account.json
+  SHEETS_SPREADSHEET=press
+  VK_SHEETS_TAB=vk
+  TG_SHEETS_TAB=tg
 
    ENABLE_VK=true
    ENABLE_TG=true


### PR DESCRIPTION
## Summary
- update README to use `SHEETS_SPREADSHEET`, `VK_SHEETS_TAB` and `TG_SHEETS_TAB`
- confirm `.exemple.env` already uses updated variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_684306202c94832a926d94c3c8a55f4e