### PR TITLE
Fix requirements list format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pyyaml
 
 pytz
 cryptography
-=======
 
 # API and authentication
 fastapi


### PR DESCRIPTION
## Summary
- remove stray separator from `requirements.txt`
- ensure `fastapi`, `uvicorn`, and `passlib[bcrypt]` stay listed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for apscheduler, gspread)*

------
https://chatgpt.com/codex/tasks/task_e_68440f100b5c832a93230abd87942590