### PR TITLE
Fix scheduler waiting loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ main.py
 import sys
 import os
 import logging
+import time
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 
@@ -111,7 +112,8 @@ def main():
         try:
             scheduler.start()
             # Блокируем основной поток, пока планировщик работает
-            scheduler.scheduler.sleep()
+            while True:
+                time.sleep(1)
         except (KeyboardInterrupt, SystemExit):
             logger.info("Остановка Scheduler по сигналу")
             scheduler.shutdown()


### PR DESCRIPTION
## Summary
- block main thread with an infinite loop instead of calling non-existent `scheduler.scheduler.sleep`

## Testing
- `pytest -q` *(fails: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_68440f1ba738832aaa55b8f26badfb8f