### PR TITLE
Fix tests for updated SheetsClient

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,220 @@
+import sys
+import types
+
+# Stub for gspread module
+if 'gspread' not in sys.modules:
+    gspread = types.ModuleType('gspread')
+    def authorize(creds):
+        return None
+    gspread.authorize = authorize
+    sys.modules['gspread'] = gspread
+
+# Stub for google.oauth2.service_account Credentials
+if 'google.oauth2.service_account' not in sys.modules:
+    google_pkg = types.ModuleType('google')
+    oauth2_pkg = types.ModuleType('google.oauth2')
+    service_account_pkg = types.ModuleType('google.oauth2.service_account')
+
+    class DummyCredentials:
+        @classmethod
+        def from_service_account_file(cls, path, scopes=None):
+            return cls()
+    service_account_pkg.Credentials = DummyCredentials
+
+    oauth2_pkg.service_account = service_account_pkg
+
+    sys.modules.setdefault('google', google_pkg)
+    sys.modules['google.oauth2'] = oauth2_pkg
+    sys.modules['google.oauth2.service_account'] = service_account_pkg
+
+# Stub for apscheduler modules used in scheduler
+if 'apscheduler.schedulers.background' not in sys.modules:
+    aps_pkg = types.ModuleType('apscheduler')
+    schedulers_pkg = types.ModuleType('apscheduler.schedulers')
+    background_pkg = types.ModuleType('apscheduler.schedulers.background')
+
+    class DummyJob:
+        def __init__(self, func, trigger, args, id):
+            self.func = func
+            self.trigger = trigger
+            self.args = args
+            self.id = id
+
+    class DummyBackgroundScheduler:
+        def __init__(self, timezone=None):
+            self.jobs = {}
+            self.timezone = timezone
+        def add_job(self, func, trigger, args=None, id=None, replace_existing=False):
+            job = DummyJob(func, trigger, args or [], id)
+            self.jobs[id] = job
+            return job
+        def get_job(self, id):
+            return self.jobs.get(id)
+        def remove_job(self, id):
+            self.jobs.pop(id, None)
+        def start(self):
+            pass
+        def shutdown(self):
+            pass
+
+    background_pkg.BackgroundScheduler = DummyBackgroundScheduler
+    schedulers_pkg.background = background_pkg
+
+    triggers_pkg = types.ModuleType('apscheduler.triggers')
+    cron_pkg = types.ModuleType('apscheduler.triggers.cron')
+
+    class DummyCronTrigger:
+        def __init__(self, expr, timezone=None):
+            self.expr = expr
+            self.timezone = timezone
+        @classmethod
+        def from_crontab(cls, expr, timezone=None):
+            return cls(expr, timezone)
+        def __str__(self):
+            return self.expr
+
+    cron_pkg.CronTrigger = DummyCronTrigger
+    triggers_pkg.cron = cron_pkg
+
+    aps_pkg.schedulers = schedulers_pkg
+    aps_pkg.triggers = triggers_pkg
+
+    sys.modules['apscheduler'] = aps_pkg
+    sys.modules['apscheduler.schedulers'] = schedulers_pkg
+    sys.modules['apscheduler.schedulers.background'] = background_pkg
+    sys.modules['apscheduler.triggers'] = triggers_pkg
+    sys.modules['apscheduler.triggers.cron'] = cron_pkg
+
+# Stub for pytz module
+if 'pytz' not in sys.modules:
+    pytz = types.ModuleType('pytz')
+    def timezone(name):
+        return name
+    pytz.timezone = timezone
+    sys.modules['pytz'] = pytz
+
+# Stub for requests.exceptions
+if 'requests' not in sys.modules:
+    requests = types.ModuleType('requests')
+    exc = types.ModuleType('requests.exceptions')
+    class ConnectionError(Exception):
+        pass
+    exc.ConnectionError = ConnectionError
+    requests.exceptions = exc
+    sys.modules['requests'] = requests
+    sys.modules['requests.exceptions'] = exc
+
+# Stub for yaml module
+if 'yaml' not in sys.modules:
+    yaml = types.ModuleType('yaml')
+    def safe_load(stream):
+        return {}
+    yaml.safe_load = safe_load
+    sys.modules['yaml'] = yaml
+
+# Stub for pydantic_settings.BaseSettings if package is missing
+if 'pydantic_settings' not in sys.modules:
+    from pydantic import BaseModel
+    ps = types.ModuleType('pydantic_settings')
+
+    class BaseSettings(BaseModel):
+        class Config:
+            extra = 'allow'
+
+        def __init__(self, **data):
+            env_values = {
+                name: os.environ.get(name)
+                for name in self.__class__.__fields__
+                if os.environ.get(name) is not None
+            }
+            env_values.update(data)
+            super().__init__(**env_values)
+
+    ps.BaseSettings = BaseSettings
+    sys.modules['pydantic_settings'] = ps
+
+import os
+
+os.environ.setdefault('GOOGLE_CREDENTIALS_PATH', 'dummy.json')
+os.environ.setdefault('SHEETS_SPREADSHEET', 'dummy_sheet')
+os.environ.setdefault('VK_SHEETS_TAB', 'vk')
+os.environ.setdefault('TG_SHEETS_TAB', 'tg')
+os.environ.setdefault('OPENAI_API_KEY', 'key')
+os.environ.setdefault('YANDEX_API_KEY', 'key')
+os.environ.setdefault('YANDEX_CLOUD_FOLDER_ID', 'folder')
+os.environ.setdefault('FUSIONBRAIN_API_SECRET', 'secret')
+
+# Stub for openai module
+if 'openai' not in sys.modules:
+    openai = types.ModuleType('openai')
+    chat_pkg = types.SimpleNamespace(completions=types.SimpleNamespace(create=lambda **kwargs: types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=""))], usage=types.SimpleNamespace(total_tokens=0))))
+    images_pkg = types.SimpleNamespace(generate=lambda **kwargs: types.SimpleNamespace(data=[{"b64_json": ""}]))
+    openai.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=lambda **kwargs: types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=""))], usage=types.SimpleNamespace(total_tokens=0))))
+    openai.images = types.SimpleNamespace(generate=lambda **kwargs: types.SimpleNamespace(data=[{"b64_json": ""}]))
+    sys.modules['openai'] = openai
+
+# Stub for telegram module
+if 'telegram' not in sys.modules:
+    telegram = types.ModuleType('telegram')
+    telegram.Bot = object
+    telegram.InputFile = object
+    constants = types.ModuleType('telegram.constants')
+    constants.ParseMode = types.SimpleNamespace(MARKDOWN='Markdown')
+    error_pkg = types.ModuleType('telegram.error')
+    class TelegramError(Exception):
+        pass
+    error_pkg.TelegramError = TelegramError
+    telegram.constants = constants
+    telegram.error = error_pkg
+    sys.modules['telegram'] = telegram
+    sys.modules['telegram.constants'] = constants
+    sys.modules['telegram.error'] = error_pkg
+
+# Stub for chromadb module
+if 'chromadb' not in sys.modules:
+    chromadb = types.ModuleType('chromadb')
+    class PersistentClient:
+        def __init__(self, path=None, settings=None):
+            self.path = path
+            self.settings = settings
+        def get_or_create_collection(self, name, embedding_function=None):
+            return types.SimpleNamespace(
+                add=lambda **kwargs: None,
+                get=lambda **kwargs: {"ids": [], "documents": [], "metadatas": []},
+            )
+    chromadb.PersistentClient = PersistentClient
+    config_pkg = types.ModuleType('chromadb.config')
+    class Settings:
+        def __init__(self, **kwargs):
+            pass
+    config_pkg.Settings = Settings
+    utils_pkg = types.ModuleType('chromadb.utils')
+    ef_pkg = types.ModuleType('chromadb.utils.embedding_functions')
+    class OpenAIEmbeddingFunction:
+        def __init__(self, api_key=None, model_name=None):
+            pass
+    ef_pkg.OpenAIEmbeddingFunction = OpenAIEmbeddingFunction
+    utils_pkg.embedding_functions = ef_pkg
+    sys.modules['chromadb'] = chromadb
+    sys.modules['chromadb.config'] = config_pkg
+    sys.modules['chromadb.utils'] = utils_pkg
+    sys.modules['chromadb.utils.embedding_functions'] = ef_pkg
+
+# Stub for PIL.Image
+if 'PIL' not in sys.modules:
+    PIL = types.ModuleType('PIL')
+    image_pkg = types.ModuleType('PIL.Image')
+    class Image:
+        LANCZOS = 1
+        @staticmethod
+        def open(fp):
+            class Img:
+                def thumbnail(self, size, resample):
+                    pass
+                def save(self, buf, format=None, quality=85):
+                    pass
+            return Img()
+    image_pkg.Image = Image
+    PIL.Image = Image
+    sys.modules['PIL'] = PIL
+    sys.modules['PIL.Image'] = image_pkg

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -19,11 +19,13 @@ def test_schedule_added_and_removed(monkeypatch):
         cron="*/5 * * * *",
         enabled=True,
         prompt_key="post_intro",
+        generator="openai",
     )
 
     monkeypatch.setattr(settings, "SCHEDULES", [sched])
 
     scheduler = Scheduler()
+    scheduler.add_schedule(sched)
 
     job_id = f"vk_{sched.id}"
     job = scheduler.scheduler.get_job(job_id)
@@ -49,12 +51,14 @@ def test_scheduler_registers_jobs(monkeypatch):
                 module="vk",
                 cron="*/1 * * * *",  # каждую минуту
                 enabled=True,
-                prompt_key="post_intro"
+                prompt_key="post_intro",
+                generator="openai"
             )
         ]
     )
 
     scheduler = Scheduler()
+    scheduler.start()
 
     job_id = "vk_job1"
     job = scheduler.scheduler.get_job(job_id)
@@ -76,7 +80,8 @@ def test_publish_for_vk_no_tasks(monkeypatch):
         module="vk",
         cron="*/1 * * * *",
         enabled=True,
-        prompt_key="post_intro"
+        prompt_key="post_intro",
+        generator="openai"
     )
     # Должно пройти без исключений
     publish_for_vk(fake_sched)

--- a/tests/test_sheets.py
+++ b/tests/test_sheets.py
@@ -1,25 +1,32 @@
 import sys
 import os
-# Добавляем корень проекта (project-root) в PYTHONPATH
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import pytest
+
 from src.sheets.sheets_client import SheetsClient
-from src.core.models import Post
+from src.config.settings import settings
 
-# Заглушки для Google Sheets API
+
 class DummySheet:
-    def __init__(self, records):
-        # Храним изначальные записи и отслеживаем обновления
-        self._records = records
-        self.updated = None
+    def __init__(self, rows):
+        self.rows = rows
+        self.updated_cells = []
 
-    def get_all_records(self):
-        return self._records
+    def get_all_values(self):
+        return self.rows
 
-    def update(self, cell_range, values):
-        # Сохраняем, какие данные были переданы в update
-        self.updated = (cell_range, values)
+    def row_values(self, idx):
+        return self.rows[idx - 1]
+
+    def update_cell(self, row, col, value):
+        while len(self.rows) < row:
+            self.rows.append([])
+        row_list = self.rows[row - 1]
+        while len(row_list) < col:
+            row_list.append('')
+        row_list[col - 1] = value
+        self.updated_cells.append((row, col, value))
 
 
 class DummySpreadsheet:
@@ -34,98 +41,64 @@ class DummyGspreadClient:
     def __init__(self, sheet):
         self._sheet = sheet
 
-    def open(self, name):
-        # Возвращаем объект с методом worksheet()
+    def open_by_key(self, key):
+        return DummySpreadsheet(self._sheet)
+
+    def open_by_url(self, url):
         return DummySpreadsheet(self._sheet)
 
 
 class DummyCredentials:
-    pass
+    @classmethod
+    def from_service_account_file(cls, path, scopes=None):
+        return cls()
 
 
 @pytest.fixture
 def dummy_sheet(monkeypatch):
-    """
-    Фикстура, которая подменяет авторизацию Google Sheets
-    и возвращает DummySheet с одной записью в статусе 'ожидание'.
-    """
-
-    # Подготовим «лист» с ровно одной записью: status = 'ожидание'
-    records = [
-        {"idea": "Idea1", "status": "ожидание", "scheduled": "", "socialnet": "",
-         "url": "", "ai": "", "model": "", "notes": ""}
+    rows = [
+        ["idea", "status", "scheduled", "socialnet", "url", "ai", "model", "notes"],
+        ["Idea1", "ожидание", "", "", "", "", "", ""],
     ]
-    sheet = DummySheet(records)
+    sheet = DummySheet(rows)
 
-    # Замокать Credentials.from_service_account_file → возвращает DummyCredentials
     monkeypatch.setattr(
         "src.sheets.sheets_client.Credentials.from_service_account_file",
-        lambda path, scopes: DummyCredentials()
+        lambda path, scopes=None: DummyCredentials(),
     )
-
-    # Замокать gspread.authorize → возвращает DummyGspreadClient(sheet)
     monkeypatch.setattr(
         "src.sheets.sheets_client.gspread.authorize",
-        lambda creds: DummyGspreadClient(sheet)
+        lambda creds: DummyGspreadClient(sheet),
     )
+    monkeypatch.setattr(settings, "GOOGLE_CREDENTIALS_PATH", "fake.json", raising=False)
+    monkeypatch.setattr(settings, "SHEETS_SPREADSHEET", "dummy", raising=False)
 
     return sheet
 
 
 def test_get_next_post(dummy_sheet):
-    """
-    Проверяем, что get_next_post() вернёт Post с полем idea="Idea1"
-    и номер строки 2 (учитывая, что header – это строка 1).
-    """
-    client = SheetsClient(
-        credentials_json_path="fake_path.json",
-        spreadsheet_name="press",
-        sheet_name="smm"
-    )
-
-    post, idx = client.get_next_post()
-    # Должны вернуть модель Post и индекс 2
-    assert isinstance(post, Post)
-    assert post.idea == "Idea1"
-    assert idx == 2  # первая строка – header, вторая – наша запись
+    client = SheetsClient()
+    idx, row = client.get_next_post(sheet_name="smm")
+    assert idx == 2
+    assert row["idea"] == "Idea1"
 
 
-def test_update_post(dummy_sheet):
-    """
-    Проверяем, что update_post() обновляет нужный диапазон ("A2:H2")
-    и передаёт корректные значения.
-    """
-    client = SheetsClient(
-        credentials_json_path="fake_path.json",
-        spreadsheet_name="press",
-        sheet_name="smm"
-    )
-
-    # Создаём фиктивный Post с обновлёнными полями
-    post = Post(
-        idea="Idea1",
+def test_update_post_status_and_meta(dummy_sheet):
+    client = SheetsClient()
+    client.update_post_status_and_meta(
+        sheet_name="smm",
+        row_index=2,
         status="выполнено",
         scheduled="2025-06-01 10:00",
-        socialnet="vk",
         url="https://vk.com/wall-12345_6789",
         ai="ChatGPT",
         model="gpt-4o",
-        notes="Tokens: 100, Cost: 0.02"
+        notes="Tokens: 100, Cost: 0.02",
     )
-    client.update_post(2, post)
-
-    # sheet.updated должен быть установлен кортежем (cell_range, values)
-    assert dummy_sheet.updated is not None
-
-    cell_range, values = dummy_sheet.updated
-    # Проверяем, что диапазон для обновления правильный
-    assert cell_range == "A2:H2"
-    # values — вложенный список, первая строка – это [idea, status, scheduled, ...]
-    assert values[0][0] == "Idea1"
-    assert values[0][1] == "выполнено"
-    assert values[0][2] == "2025-06-01 10:00"
-    assert values[0][3] == "vk"
-    assert values[0][4] == "https://vk.com/wall-12345_6789"
-    assert values[0][5] == "ChatGPT"
-    assert values[0][6] == "gpt-4o"
-    assert values[0][7] == "Tokens: 100, Cost: 0.02"
+    row = dummy_sheet.rows[1]
+    assert row[1] == "выполнено"
+    assert row[2] == "2025-06-01 10:00"
+    assert row[4] == "https://vk.com/wall-12345_6789"
+    assert row[5] == "ChatGPT"
+    assert row[6] == "gpt-4o"
+    assert row[7] == "Tokens: 100, Cost: 0.02"


### PR DESCRIPTION
## Summary
- adjust tests to use settings-based SheetsClient initialization
- add conftest with stubs for external packages
- update scheduler tests for new ScheduleConfig fields and job registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844127e42d8832aae787643451899f2