### PR TITLE
Add StatsInterface for statistics collection

### DIFF
--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -90,3 +90,23 @@ class PublisherInterface(ABC):
                            Если публикация не удалась, вернуть None или бросить исключение.
         """
         raise NotImplementedError
+
+
+class StatsInterface(ABC):
+    """
+    Интерфейс для сбора статистики по опубликованным постам.
+    Классы-наследники должны реализовать метод ``collect``.
+    """
+
+    @abstractmethod
+    def collect(self, post_url: str) -> Dict:
+        """
+        Возвращает статистику по публикации.
+
+        Args:
+            post_url (str): URL или идентификатор опубликованного поста.
+
+        Returns:
+            Dict: словарь со статистикой (лайки, просмотры и др.).
+        """
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- introduce `StatsInterface` abstract base class in `core.interfaces`
- reference `StatsInterface` in Telegram statistics module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684417a05f60832aa301bd2df309555d