### PR TITLE
Improve get_last_by_network and add tests

### DIFF
--- a/src/vector_db/vector_client.py
+++ b/src/vector_db/vector_client.py
@@ -152,16 +152,18 @@ class VectorClient:
         metadatas = results.get("metadatas", [])
 
         # Если нет записей
-        if not documents or len(documents) == 0:
+        if not documents:
             return None
 
-        doc_list = documents[0]
-        meta_list = metadatas[0]
+        # chromadb может возвращать плоский список документов и метаданных,
+        # либо список, вложенный в ещё один список (как в методе query).
+        doc_list = documents[0] if documents and isinstance(documents[0], list) else documents
+        meta_list = metadatas[0] if metadatas and isinstance(metadatas[0], list) else metadatas
 
         latest_text = None
         latest_ts = None
 
-        for idx, meta in enumerate(meta_list):
+        for doc, meta in zip(doc_list, meta_list):
             created_str = meta.get("created_at")
             if not created_str:
                 continue
@@ -172,7 +174,7 @@ class VectorClient:
 
             if latest_ts is None or created > latest_ts:
                 latest_ts = created
-                latest_text = doc_list[idx]
+                latest_text = doc
 
         return latest_text
 

--- a/tests/test_vector_db.py
+++ b/tests/test_vector_db.py
@@ -1,0 +1,55 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.vector_db.vector_client import VectorClient
+
+
+class DummyCollection:
+    def __init__(self, docs, metas):
+        self.docs = docs
+        self.metas = metas
+
+    def add(self, **kwargs):
+        pass
+
+    def get(self, **kwargs):
+        # chromadb returns list[str] and list[dict]
+        return {"ids": ["1" for _ in self.docs], "documents": self.docs, "metadatas": self.metas}
+
+
+class DummyPersistentClient:
+    def __init__(self, path=None, settings=None):
+        pass
+
+    def get_or_create_collection(self, name, embedding_function=None):
+        return self.collection
+
+
+def test_get_last_by_network(monkeypatch):
+    docs = [
+        "first text",
+        "second text",
+        "third text",
+    ]
+    metas = [
+        {"network": "vk", "created_at": "2024-06-01T10:00:00"},
+        {"network": "vk", "created_at": "2024-06-02T09:00:00"},
+        {"network": "vk", "created_at": "2024-05-30T08:00:00"},
+    ]
+
+    dummy_collection = DummyCollection(docs, metas)
+    client = DummyPersistentClient()
+    client.collection = dummy_collection
+
+    # Подменяем chromadb.PersistentClient, чтобы вернуть dummy client
+    monkeypatch.setattr("chromadb.PersistentClient", lambda *a, **k: client)
+
+    vc = VectorClient(
+        persist_directory="/tmp",
+        collection_name="test",
+        embedding_model="model",
+    )
+
+    last = vc.get_last_by_network("vk")
+    assert last == "second text"


### PR DESCRIPTION
## Summary
- handle flat and nested lists returned by `chromadb.get`
- return the document with the latest `created_at` using zipped iteration
- add unit test for `get_last_by_network`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684419ba4758832aabdf31cd080d7217